### PR TITLE
Remove scroll constraints from response container

### DIFF
--- a/css/mha-app.css
+++ b/css/mha-app.css
@@ -38,11 +38,9 @@ input {
 }
 
 #response {
-  overflow-y: auto;
   position: static;
   width: 100%;
   padding-bottom: 0;
-  max-height: 70vh;
 }
 
 #response table {


### PR DESCRIPTION
## Summary
Removed overflow and max-height constraints from the `#response` element to allow it to expand naturally without scroll limitations.

## Key Changes
- Removed `overflow-y: auto;` property that was enabling vertical scrolling
- Removed `max-height: 70vh;` constraint that was limiting the container height to 70% of viewport

## Details
These changes allow the response container to grow dynamically based on its content rather than being constrained to a fixed maximum height with internal scrolling. The container will now expand to accommodate all content naturally while maintaining its static positioning and full width.
